### PR TITLE
fix version note

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+  {{ partial "page/get-version-info" . }}
   {{ partial "nav/main" . }}
 
   <section class="md:ml-80 xl:ml-96">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96 xl:mr-56">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+  {{ partial "page/get-version-info" . }}
   {{ partial "nav/main" . }}
 
   <section class="md:ml-80 xl:ml-96">

--- a/layouts/lib/common-data.html
+++ b/layouts/lib/common-data.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96 xl:mr-56">

--- a/layouts/lib/data-type.html
+++ b/layouts/lib/data-type.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96 xl:mr-56">

--- a/layouts/lib/enum.html
+++ b/layouts/lib/enum.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96 xl:mr-56">

--- a/layouts/lib/function.html
+++ b/layouts/lib/function.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96 xl:mr-56">

--- a/layouts/lib/overview.html
+++ b/layouts/lib/overview.html
@@ -1,4 +1,5 @@
 {{ define "main" }}
+    {{ partial "page/get-version-info" . }}
     {{ partial "nav/main" . }}
 
     <section class="md:ml-80 xl:ml-96">

--- a/layouts/partials/body/version-note.html
+++ b/layouts/partials/body/version-note.html
@@ -1,13 +1,19 @@
 {{ with .Page.Scratch.Get "versioning" }}
-  {{ $note := "" }} 
+  {{ $note := "" }}
   <div class="w-full mt-2 mb-8">
-    <div class="flex-grow px-4 py-4 bg-default-soft border-l-4 border-brand">      
+    <div class="flex-grow px-4 py-4 bg-default-soft border-l-4 border-brand">
       {{ if not .isLatestVersion }}
-        {{ $note = printf "This is part of %v `%v` -- *latest release: `%v`*." $.Title .thisVersion .latestVersion }}
+        {{ $note = printf "This is part of %v `%v` -- *latest release: `%v`*." .versionedSection .thisVersion .latestVersion }}
+        {{ if .devVersion }}
+          {{ $note = printf "This is part of %v `%v` -- *latest release: `%v`*.<br>**🚧 Development version -- not released yet! 🚧**" .versionedSection .thisVersion .latestVersion }}
+        {{ end }}
+        {{ if .betaVersion }}
+          {{ $note = printf "This is part of %v `%v` -- *latest release: `%v`*.<br>**🧪 Beta version -- use at own risk! 🧪**" .versionedSection .thisVersion .latestVersion }}
+        {{ end }}
       {{ else }}
-        {{ $note = printf "This is part of %v `%v` -- *latest release*." $.Title .thisVersion }}
+        {{ $note = printf "This is part of %v `%v` -- *latest release*." .versionedSection .thisVersion }}
       {{ end }}
-      {{ $note | markdownify }} 
+      {{ $note | markdownify }}
     </div>
   </div>
 {{end}}

--- a/layouts/partials/page/get-version-info.html
+++ b/layouts/partials/page/get-version-info.html
@@ -1,15 +1,26 @@
 {{/* page part of a versioned section? */}}
 {{ if .Site.Data.import }}
   {{ with .Site.GetPage .Section }}
-    {{ with index .Site.Data.import .Title }}
+    {{ $sectionTitle := .Title }}
+    {{ with index .Site.Data.import $sectionTitle }}
       {{ $versioning := dict }}
+      {{ $versioning = $versioning | merge (dict "sectionTitle" $sectionTitle) }}
       {{ $versioning = $versioning | merge (dict "isVersioned" true) }}
       {{ $versioning = $versioning | merge (dict "versions" .) }}
       {{ $versioning = $versioning | merge (dict "latestVersion" (index . 0)) }}
       {{ range . }}
         {{ if in $.Section ( . | replaceRE "-.*" "") }}
           {{ $versioning = $versioning | merge (dict "thisVersion" .) }}
-        {{end}} 
+
+          {{/* special versions */}}
+          {{ if in . "-dev" }}
+            {{ $versioning = $versioning | merge (dict "devVersion" true) }}
+          {{end}}
+          {{ if in . "-beta" }}
+            {{ $versioning = $versioning | merge (dict "betaVersion" true) }}
+          {{end}}
+
+        {{end}}
       {{end}}
       {{ if eq $versioning.thisVersion $versioning.latestVersion }}
         {{ $versioning = $versioning | merge (dict "isLatestVersion" true) }}


### PR DESCRIPTION
- Adds special version note for `-dev` and `-beta` versions.
- Call `get-version-info` at top of each layout, since calling it in a loop in `/index.html` seems not suffiect.